### PR TITLE
Update to liquid 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,5 @@ exclude = [
 
 [dependencies]
 redis = "0.5.2"
+liquid = "0.4"
 
-[dependencies.liquid]
-git = "https://github.com/FerarDuanSednan/liquid-rust.git"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let text = r#"
 "#;
 
 let mut options : LiquidOptions = Default::default();
-options.blocks.insert("cache".to_string(), Box::new(RawCacheBlock::new("./tests/tmp")) as Box<Block>); 
+options.blocks.insert("cache".to_string(), Box::new(RawCacheBlock::new("./tests/tmp")));
 
 let template = parse(&text, &mut options).unwrap();
 
@@ -53,7 +53,7 @@ let text = r#"
 "#;
 
 let mut options : LiquidOptions = Default::default();
-options.blocks.insert("cache".to_string(), Box::new(RedisCacheBlock::new(con.clone())) as Box<Block>); 
+options.blocks.insert("cache".to_string(), Box::new(RedisCacheBlock::new(con.clone())));
 
 let template = parse(&text, &mut options).unwrap();
 

--- a/src/tags/redis_cache.rs
+++ b/src/tags/redis_cache.rs
@@ -9,40 +9,34 @@ use redis::Connection;
 use cache::RedisCache;
 use tags::CacheT;
 
-pub struct RedisCacheBlock {
-    conn: Arc<Mutex<Connection>>,
-}
+pub struct RedisCacheBlock;
 
 impl RedisCacheBlock {
-    pub fn new(connection: Arc<Mutex<Connection>>) -> RedisCacheBlock {
-        RedisCacheBlock { conn: connection }
-    }
-}
+    pub fn new(connection: Arc<Mutex<Connection>>) -> Box<Block> {
+        let initialize = move |_tag_name: &str,
+                               arguments: &[Token],
+                               tokens: Vec<Element>,
+                               options: &LiquidOptions|
+                               -> Result<Box<Renderable>, liquid::Error> {
+            let mut args = arguments.iter();
+            let inner = try!(parse(&tokens, options));
 
-impl Block for RedisCacheBlock {
-    fn initialize<'a>(&'a self,
-                      _tag_name: &str,
-                      arguments: &[Token],
-                      tokens: Vec<Element>,
-                      options: &'a LiquidOptions)
-                      -> Result<Box<Renderable + 'a>, liquid::Error> {
+            let cache_key = match args.next() {
+                Some(&Token::Identifier(ref x)) => x.clone(),
+                x => {
+                    return Err(liquid::Error::Parser(format!("Expected an identifier, found {:?}",
+                                                             x)))
+                }
+            };
 
-        let mut args = arguments.iter();
-        let inner = try!(parse(&tokens, options));
-
-        let cache_key = match args.next() {
-            Some(&Token::Identifier(ref x)) => x.clone(),
-            x => {
-                return Err(liquid::Error::Parser(format!("Expected an identifier, found {:?}", x)))
-            }
+            let cachet = CacheT {
+                engine: Box::new(RedisCache::new(connection.clone())),
+                cache_key: cache_key,
+                inner: Template::new(inner),
+            };
+            Ok(Box::new(cachet))
         };
-
-        let cachet = CacheT {
-            engine: Box::new(RedisCache::new(self.conn.clone())),
-            cache_key: cache_key,
-            inner: Template::new(inner),
-        };
-        Ok(Box::new(cachet) as Box<Renderable>)
+        return Box::new(initialize);
     }
 }
 

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -1,7 +1,7 @@
 extern crate liquid;
 extern crate liquid_cache as lrc;
 
-use liquid::{Renderable, Block, LiquidOptions, parse, Context, Value};
+use liquid::{Renderable, LiquidOptions, parse, Context, Value};
 
 use lrc::{RawCacheBlock};
 
@@ -19,9 +19,9 @@ fn raw_cache() {
     "#;
 
     let mut options : LiquidOptions = Default::default();
-    options.blocks.insert("cache".to_string(), Box::new(RawCacheBlock::new("./tests/tmp")) as Box<Block>); 
+    options.blocks.insert("cache".to_string(), RawCacheBlock::new("./tests/tmp"));
 
-    let template = parse(&text, &mut options).unwrap();
+    let template = parse(&text, options).unwrap();
 
     let mut data = Context::new();
     data.set_val("vec", Value::Array(vec));

--- a/tests/redis.rs
+++ b/tests/redis.rs
@@ -4,7 +4,7 @@ extern crate liquid_cache as lrc;
 
 use std::sync::{Arc, Mutex};
 
-use liquid::{Renderable, Block, LiquidOptions, parse, Context, Value};
+use liquid::{Renderable, LiquidOptions, parse, Context, Value};
 
 use lrc::{RedisCacheBlock};
 
@@ -27,9 +27,9 @@ fn redis_cache() {
     "#;
 
     let mut options : LiquidOptions = Default::default();
-    options.blocks.insert("cache".to_string(), Box::new(RedisCacheBlock::new(con.clone())) as Box<Block>); 
+    options.blocks.insert("cache".to_string(), RedisCacheBlock::new(con.clone()));
 
-    let template = parse(&text, &mut options).unwrap();
+    let template = parse(&text, options).unwrap();
 
     let mut data = Context::new();
     data.set_val("vec", Value::Array(vec));


### PR DESCRIPTION
This update keeps up with the breaking changes in liquid 0.4, now using
boxed closures instead of trait objects for creating tags.

Also, the `LiquidOptions` object is now consumed by `parse`.

Sorry for the breakage! I think using `Fn` to build tags simplifies the API and makes the internal code much simpler.
